### PR TITLE
Fix java version check

### DIFF
--- a/fpm/scripts/before-install.sh
+++ b/fpm/scripts/before-install.sh
@@ -26,9 +26,12 @@ echo -n "Checking Java version ... "
 JAVA_VERSION=$(java -version 2>&1)
 [ $? != 0 ] && echo -e "NOT FOUND\nPlease install Java 21 or later and try again" && exit 2
 
-VERSION=`expr "$JAVA_VERSION" : '.*"\(21\..*\)["_]'`
+if [[ $JAVA_VERSION =~ .*\"(1\.)?([0-9]{1,2})\.[^\"_]+ ]]
+then
+  VERSION="${BASH_REMATCH[2]}"
+fi
 echo "$VERSION"
-test "$VERSION" "<" "17" && echo "ERROR: Java 21 or later is required by Gerrit" && exit 3
+test "$VERSION" -lt "21" && echo "ERROR: Java 21 or later is required by Gerrit" && exit 3
 
 # Script is invoked even before upgrade, we need to stop Gerrit if active
 GERRIT_PID=$(ps -o pid,command -u $USER | grep gerrit | awk '{print $1}')


### PR DESCRIPTION
Somehow I failed to push to gerrit - thus this PR.

The version check previously had multiple flaws.
The new check should correctly return only the major version number, even for java 8 (identified as "1.8.x").

Tested against multiple versions of `java -version` output.
See https://regex101.com/r/x4rhvD/2

I also fail to understand why it is necessary to look for the java version during the installation of Gerrit anyway. What if I have a different `JAVA_HOME` set in `/etc/default/gerritcodereview` or `javaHome` in `gerrt.config`?
Java version check should be implemented in gerrit.sh - if anywhere.